### PR TITLE
Add name parameter usage to CadOverlay API doc [AM-1102]

### DIFF
--- a/docs/cad-overlay.md
+++ b/docs/cad-overlay.md
@@ -14,9 +14,11 @@ const headers = {
   "Authorization": "Bearer mysecretbearertoken",
   "X-Custom": "custom-header-value-for-mysite",
 };
+const name = 'My Overlay Image Name'
 
 // Call the import function
-dronedeployAPI.CadOverlay.import(url, headers);
+// NOTE: headers and name are optional parameters
+dronedeployAPI.CadOverlay.import(url, headers, name);
 ```
 
 **How to Use**


### PR DESCRIPTION
### Ticket
https://dronedeploy.atlassian.net/browse/AM-1102

### Work Done
- Use `name` parameter for `CadOverlay` API in basic overview example code