### PR TITLE
Add a yaml file for github to gitbook syncing [AM-1461]

### DIFF
--- a/gitbook.yaml
+++ b/gitbook.yaml
@@ -1,0 +1,5 @@
+root: ./docs/
+
+structure:
+  readme: README.md
+  summary: SUMMARY.md


### PR DESCRIPTION
Syncing with GitHub requires a .yaml file to be present:

https://docs.gitbook.com/integrations/github/limitations#common-errors