### PR TITLE
Change /docs links and no longer build /docs [AM-1366]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@ package: clean build-graphql-reference
 			-v $(PWD)/_book:/gitbook/_book/ \
 			dronedeploy/nodejs:v8.9.0 \
 			/bin/bash -c "npm install -g gitbook-cli; gitbook install; gitbook build"
-	cp -R ./_book build/
-	mv build/_book/ build/docs
 	cp -R landing_page/* build/
 
 run:

--- a/landing_page/index.html
+++ b/landing_page/index.html
@@ -80,7 +80,7 @@
         </div>
           <ul class="nav navbar-nav navbar-md-fix nav-pills">
             <li class="nav-item">
-              <a class="nav-link" href="/docs/introduction/overview.html">Docs</a>
+              <a class="nav-link" href="https://developer-docs.dronedeploy.com/introduction/overview">Docs</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="/reference/">Reference</a>
@@ -115,11 +115,8 @@
       </span>
       <!--End Mobile Hamburger-->
       <ul id="toggle-switch" class = "nav__list--main hidden-lg-up">
-<!--          <li class="nav__item">
-            <a href="https://dronedeploy.gitbooks.io/dronedeploy-apps/content/" target="_blank">Docs</a>
-        </li>
- -->          <li class="nav__item">
-            <a class="nav-link" href="/docs/introduction/overview.html">Docs</a>
+         <li class="nav__item">
+            <a class="nav-link" href="https://developer-docs.dronedeploy.com/introduction/overview">Docs</a>
           </li>
           <li class="nav__item">
             <a class="nav-link" href="/reference/">Reference</a>
@@ -140,7 +137,7 @@
       <div class="col-lg-6 col-md-12 text-info m-t-4 m-t-2-md p-b-3-lg text-xs-center text-lg-left">
         <h1 class="display-1 m-b-1">The Drone Data Platform for Developers</h1>
         <p class="lead m-b-2 m-b-1-xs m-r-1-lg m-l-1-xs text-xs-left text-sm-center text-lg-left">Build, grow, and monetize your apps with the full power of DroneDeploy—the world’s largest drone data platform.</p>
-        <a class="btn btn-secondary btn-lg" href="/docs/">Build an App</a>
+        <a class="btn btn-secondary btn-lg" href="https://developer-docs.dronedeploy.com/">Build an App</a>
         <a class="btn btn-secondary-outline btn-lg m-l-1-sm" href="https://www.dronedeploy.com/app-market.html">Browse Apps</a>
       </div>
       <div class="col-lg-6 col-md-12 center-xs">
@@ -458,10 +455,7 @@
     <div class="row text-xs-center text-info">
       <div class="col-xs-12">
         <h2 class="display-2 m-b-2">Ready to Start Building?</h2>
-        <a href="/docs/" class="btn btn-secondary btn-lg" role="button">View Docs</a>
-        <p class="small text-uppercase m-t-1">
-          <a class="text-info" href="https://dronedeploy.gitbooks.io/dronedeploy-apps/content/" target="_blank">Direct Link</a>
-        </p>
+        <a href="https://developer-docs.dronedeploy.com/" class="btn btn-secondary btn-lg" role="button">View Docs</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Remove the copy docs step from the Makefile (so you can still build+test locally)
- Update `/docs` links to new developer-docs domain
- Remove hard gitbook links